### PR TITLE
Add workspaceFolder substitution to the luaExe configuration.

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,15 @@
 import * as vscode from "vscode";
 
+function substitutePath(s: string): string {
+  const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0].uri.fsPath;
+
+  return s
+    .replace(/\${workspaceRoot}/g, workspaceFolder || "")
+    .replace(/\${workspaceFolder}/g, workspaceFolder || "");
+}
+
 export function getLuaExe(): string {
-  return getOrDefault("luaExe", "lua");
+  return substitutePath(getOrDefault("luaExe", "lua"));
 }
 
 export function getTestGlob(): string {


### PR DESCRIPTION
I want to specify the lua interpreter built in project local.
Useful when using luarocks in project local.

I used the following as a reference.
https://github.com/vscode-shellcheck/vscode-shellcheck/issues/713#issuecomment-1231868196

Thank you .
